### PR TITLE
Parse network related variables in cmdline options and add hostname fallback function

### DIFF
--- a/install/util.h
+++ b/install/util.h
@@ -507,6 +507,42 @@ void* memdup(const void *p, size_t l);
 
 int is_kernel_thread(pid_t pid);
 
+static inline void freep(void *p) {
+        free(*(void**) p);
+}
+
+static inline void fclosep(FILE **f) {
+        if (*f)
+                fclose(*f);
+}
+
+static inline void pclosep(FILE **f) {
+        if (*f)
+                pclose(*f);
+}
+
+static inline void closep(int *fd) {
+        if (*fd >= 0)
+                close_nointr_nofail(*fd);
+}
+
+static inline void closedirp(DIR **d) {
+        if (*d)
+                closedir(*d);
+}
+
+static inline void umaskp(mode_t *u) {
+        umask(*u);
+}
+
+#define _cleanup_free_ _cleanup_(freep)
+#define _cleanup_fclose_ _cleanup_(fclosep)
+#define _cleanup_pclose_ _cleanup_(pclosep)
+#define _cleanup_close_ _cleanup_(closep)
+#define _cleanup_closedir_ _cleanup_(closedirp)
+#define _cleanup_umask_ _cleanup_(umaskp)
+#define _cleanup_globfree_ _cleanup_(globfree)
+
 int fd_inc_sndbuf(int fd, size_t n);
 int fd_inc_rcvbuf(int fd, size_t n);
 

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -63,7 +63,7 @@ do_fips()
     info "Loading and integrity checking all crypto modules"
     for module in $FIPSMODULES; do
         if [ "$module" != "tcrypt" ]; then
-            modprobe ${module} || return 1
+            modprobe ${module}
         fi
     done
     info "Self testing crypto algorithms"

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -422,3 +422,8 @@ net_add_parse_vars() {
 		[ -f /tmp/40network.parse.finished."${jobid}" ]
 	EOF
 }
+
+type hostname >/dev/null 2>&1 || \
+hostname() {
+	cat /proc/sys/kernel/hostname
+}

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -366,3 +366,59 @@ linkup() {
      && wait_for_if_up $1 2>/dev/null
 }
 
+# net_parse_vars STRING IFUP
+# parse vars in STRING
+# IFUP may contain the interface that came online, triggering this hook
+net_parse_vars() {
+	local cur="$1" ifup="$2" var val iface
+
+	var="${cur#*%\{}"
+	var="${var%%\}*}"
+
+	while [ "${var}" != "${cur}" ] ; do
+		case "${var}" in
+			mac.*)
+				iface="${var##mac.}"
+				[ "${ifup}" = "${iface}" ] || exit
+				val="$(ip link show dev "${iface}" | sed -nre '/ether/s/^.*ether ([0-9a-f:]*) .*$/\1/' -e 's/://')"
+				;;
+			hostname)
+				val="$(hostname)"
+				[ "${val}" = '(none)' ] && die 'No hostname (yet)'
+				;;
+			*)
+				die "Unsupported cmdline variable '${var}'"
+				;;
+		esac
+
+		cur="$(echo "${cur}" | sed "s/%{${var}}/${val}/")"
+		unset val
+
+		var="${cur#*%\{}"
+		var="${var%%\}*}"
+	done
+
+	echo "${cur}"
+}
+
+# net_add_parse_vars STRING LIB FUNCTION
+# add initqueue/online hook to parse vars in STRING
+# execute FUNCTION from LIB afterwards
+net_add_parse_vars() {
+	local string="$1" lib="$2" func="$3" jobid="$(cat /proc/sys/kernel/random/uuid)"
+
+	cat <<- EOF > "${hookdir}"/initqueue/online/40network.parse."${jobid}".sh
+		. /lib/"${lib}".sh
+
+		string="\$(net_parse_vars "${string}" "\$@")"
+		${func} "\${string}"
+		unset string
+
+		> /tmp/40network.parse.finished."${jobid}"
+	EOF
+
+	cat <<- EOF > "${hookdir}"/initqueue/finished/40network.parse.wait."${jobid}".sh
+		echo "Waiting for nfs_parse_vars (${jobid}) to complete ..."
+		[ -f /tmp/40network.parse.finished."${jobid}" ]
+	EOF
+}

--- a/modules.d/95zfcp/56-zfcp.rules
+++ b/modules.d/95zfcp/56-zfcp.rules
@@ -1,1 +1,1 @@
-KERNEL=="zfcp_cfdc", RUN+="/sbin/zfcpconf.sh"
+KERNEL=="zfcp", RUN+="/sbin/zfcpconf.sh"

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -926,7 +926,7 @@ _emergency_shell()
     local _name="$1"
     if [ -n "$DRACUT_SYSTEMD" ]; then
         > /.console_lock
-        echo "PS1=\"$_name:\${PWD}# \"" >/etc/profile
+        echo "PS1=\"$_name:\\\${PWD}# \"" >/etc/profile
         systemctl start dracut-emergency.service
         rm -f /etc/profile
         rm -f /.console_lock

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -16,7 +16,7 @@ test_run() {
 	-watchdog i6300esb -watchdog-action poweroff \
 	-append "root=LABEL=dracut rw systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.debug console=ttyS0,115200n81 $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing || return 1
-    grep -m 1 -q dracut-root-block-success $TESTDIR/result || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/result || return 1
 }
 
 test_setup() {
@@ -40,6 +40,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -74,7 +75,7 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
 
 
     (

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -12,7 +12,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=LABEL=dracut rw loglevel=77 systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug init=/sbin/init $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/root.ext3 || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext3 || return 1
 }
 
 test_setup() {
@@ -36,6 +36,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -70,7 +71,7 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext3 || return 1
 
 
     (

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -29,7 +29,7 @@ client_run() {
         return 1
     fi
 
-    if ! grep -m 1 -q dracut-root-block-success $TESTDIR/result; then
+    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
 	echo "CLIENT TEST END: $test_name [FAILED]"
         return 1
     fi
@@ -68,6 +68,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
         inst_simple ./fstab /etc/fstab
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -109,7 +110,7 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/dracut/root rw rootfstype=btrfs quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs || return 1
 
 
     (

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -30,7 +30,7 @@ client_run() {
         return 1
     fi
 
-    if ! grep -m 1 -q dracut-root-block-success $TESTDIR/result; then
+    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/result; then
 	echo "CLIENT TEST END: $test_name [FAILED]"
         return 1
     fi
@@ -251,7 +251,7 @@ EOF
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/fakeroot rw rootfstype=btrfs quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.btrfs || return 1
 
 
     (

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -14,7 +14,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=/dev/dracut/root rd.auto rw rd.retry=10 console=ttyS0,115200n81 selinux=0 $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
+    grep -F -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
 }
 
 test_setup() {
@@ -35,6 +35,7 @@ test_setup() {
 	    [ -f ${_terminfodir}/l/linux ] && break
 	done
 	dracut_install -o ${_terminfodir}/l/linux
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
@@ -71,8 +72,8 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/cannotreach rw rootfstype=ext2 console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $DISKIMAGE || return 1
-    eval $(grep -a -m 1 ID_FS_UUID $DISKIMAGE)
+    grep -F -m 1 -q dracut-root-block-created $DISKIMAGE || return 1
+    eval $(grep -F -a -m 1 ID_FS_UUID $DISKIMAGE)
 
     (
 	export initdir=$TESTDIR/overlay

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -13,7 +13,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2 || return 1
 }
 
 test_setup() {
@@ -34,6 +34,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -65,7 +66,7 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
     (
 	export initdir=$TESTDIR/overlay
 	. $basedir/dracut-functions.sh

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -39,7 +39,7 @@ udevadm settle
 cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
 mdadm -W /dev/md0 || :
-mdadm --detail --export /dev/md0 |grep MD_UUID > /tmp/mduuid
+mdadm --detail --export /dev/md0 |grep -F MD_UUID > /tmp/mduuid
 . /tmp/mduuid
 eval $(udevadm info --query=env --name=/dev/md0|while read line; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo $line; done;)
 { echo "dracut-root-block-created"; echo MD_UUID=$MD_UUID;  echo "ID_FS_UUID=$ID_FS_UUID";} > /dev/sda1

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -21,7 +21,7 @@ client_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "$* root=LABEL=root rw rd.retry=10 rd.info console=ttyS0,115200n81 selinux=0 rd.debug $DEBUGFAIL " \
 	-initrd $TESTDIR/initramfs.testing
-    if ! grep -m 1 -q dracut-root-block-success $TESTDIR/root.ext2; then
+    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2; then
 	echo "CLIENT TEST END: $@ [FAIL]"
 	return 1;
     fi
@@ -32,7 +32,7 @@ client_run() {
 }
 
 test_run() {
-    eval $(grep --binary-files=text -m 1 MD_UUID $TESTDIR/root.ext2)
+    eval $(grep -F --binary-files=text -m 1 MD_UUID $TESTDIR/root.ext2)
     echo "MD_UUID=$MD_UUID"
     read LUKS_UUID < $TESTDIR/luksuuid
 
@@ -75,6 +75,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -111,9 +112,9 @@ test_setup() {
 	-append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
 
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
-    eval $(grep --binary-files=text -m 1 MD_UUID $TESTDIR/root.ext2)
-    eval $(grep -a -m 1 ID_FS_UUID $TESTDIR/root.ext2)
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    eval $(grep -F --binary-files=text -m 1 MD_UUID $TESTDIR/root.ext2)
+    eval $(grep -F -a -m 1 ID_FS_UUID $TESTDIR/root.ext2)
     echo $ID_FS_UUID > $TESTDIR/luksuuid
 
     (

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -48,7 +48,7 @@ cryptsetup luksClose /dev/mapper/dracut_sda4 && \
 {
     echo "dracut-root-block-created"
     for i in /dev/sda[234]; do
-	udevadm info --query=env --name=$i|grep 'ID_FS_UUID='
+	udevadm info --query=env --name=$i|grep -F 'ID_FS_UUID='
     done
 } >/dev/sda1
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -21,7 +21,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=/dev/dracut/root rw rd.auto rd.retry=20 console=ttyS0,115200n81 selinux=0 rd.debug rootwait $LUKSARGS $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
     echo "CLIENT TEST END: [OK]"
 
     dd if=/dev/zero of=$TESTDIR/check-success.img bs=1M count=1
@@ -34,7 +34,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=/dev/dracut/root rw quiet rd.auto rd.retry=20 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img || return 1
     echo "CLIENT TEST END: [OK]"
 
     dd if=/dev/zero of=$TESTDIR/check-success.img bs=1M count=1
@@ -47,7 +47,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=/dev/dracut/root rw quiet rd.auto rd.retry=10 rd.info console=ttyS0,115200n81 selinux=0 rd.debug  $DEBUGFAIL rd.luks.uuid=failme" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/check-success.img && return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/check-success.img && return 1
     echo "CLIENT TEST END: [OK]"
 
     return 0
@@ -72,6 +72,7 @@ test_setup() {
 	inst "$basedir/modules.d/40network/dhclient-script.sh" "/sbin/dhclient-script"
 	inst "$basedir/modules.d/40network/ifup.sh" "/sbin/ifup"
 	dracut_install grep
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	find_binary plymouth >/dev/null && dracut_install plymouth
 	(cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
@@ -102,8 +103,8 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
-    cryptoUUIDS=$(grep --binary-files=text  -m 3 ID_FS_UUID $TESTDIR/root.ext2)
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    cryptoUUIDS=$(grep -F --binary-files=text  -m 3 ID_FS_UUID $TESTDIR/root.ext2)
     for uuid in $cryptoUUIDS; do
 	eval $uuid
 	printf ' rd.luks.uuid=luks-%s ' $ID_FS_UUID

--- a/test/TEST-15-BTRFSRAID/create-root.sh
+++ b/test/TEST-15-BTRFSRAID/create-root.sh
@@ -5,15 +5,15 @@ for x in 64-lvm.rules 70-mdadm.rules 99-mount-rules; do
 done
 udevadm control --reload
 # save a partition at the beginning for future flagging purposes
-sfdisk -C 655600 -H 2 -S 32 -L /dev/sda <<EOF
+sfdisk  -C 327800 -H 2 -S 32 -L /dev/sda <<EOF
 ,16
 ,,E
 ;
 ;
-,10240
-,10240
-,10240
-,10240
+,5120
+,5120
+,5120
+,5120
 EOF
 mkfs.btrfs -draid10 -mraid10 -L root /dev/sda5 /dev/sda6 /dev/sda7 /dev/sda8
 udevadm settle

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -13,14 +13,14 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=LABEL=root rw rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
+    dd if=$DISKIMAGE bs=512 count=2 | grep -F -m 1 -q dracut-root-block-success $DISKIMAGE || return 1
 }
 
 test_setup() {
     # Create the blank file to use as a root filesystem
     DISKIMAGE=$TESTDIR/TEST-15-BTRFSRAID-root.img
     rm -f $DISKIMAGE
-    dd if=/dev/null of=$DISKIMAGE bs=2M seek=1024
+    dd if=/dev/null of=$DISKIMAGE bs=1M seek=1024
 
     kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
@@ -72,7 +72,7 @@ test_setup() {
 	-append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
 
-    grep -m 1 -q dracut-root-block-created $DISKIMAGE || return 1
+    dd if=$DISKIMAGE bs=512 count=2 | grep -F -m 1 -q dracut-root-block-created || return 1
 
    (
         export initdir=$TESTDIR/overlay

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -23,7 +23,7 @@ test_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "root=live:CDLABEL=LiveCD live rw quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    grep -m 1 -q dracut-root-block-success $TESTDIR/root.img || return 1
+    grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.img || return 1
 }
 
 test_setup() {
@@ -62,6 +62,7 @@ test_setup() {
 	for f in /usr/share/syslinux/*; do
 	    inst_simple "$f"
 	done
+        inst_simple /etc/os-release
 	inst ./test-init.sh /sbin/init
 	inst $TESTDIR/initramfs.testing "/boot/initramfs-$KVERSION.img"
 	inst /boot/vmlinuz-$KVERSION

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -62,7 +62,7 @@ client_test() {
         -append "$cmdline $DEBUGFAIL rd.debug rd.retry=10 rd.info quiet  ro console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.testing
 
-    if [[ $? -ne 0 ]] || ! grep -m 1 -q nfs-OK $TESTDIR/client.img; then
+    if [[ $? -ne 0 ]] || ! grep -F -m 1 -q nfs-OK $TESTDIR/client.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -250,6 +250,7 @@ test_setup() {
         [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
         instmods nfsd sunrpc ipv6 lockd af_packet
         inst ./server-init.sh /sbin/init
+        inst_simple /etc/os-release
         inst ./hosts /etc/hosts
         inst ./exports /etc/exports
         inst ./dhcpd.conf /etc/dhcpd.conf
@@ -296,6 +297,7 @@ test_setup() {
         done
         dracut_install -o ${_terminfodir}/l/linux
         inst ./client-init.sh /sbin/init
+        inst_simple /etc/os-release
         (
             cd "$initdir"
             mkdir -p dev sys proc etc run

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -48,7 +48,7 @@ run_client() {
         -kernel /boot/vmlinuz-$KVERSION \
         -append "$* rw quiet rd.auto rd.retry=5 rd.debug rd.info  console=ttyS0,115200n81 selinux=0 $DEBUGFAIL" \
         -initrd $TESTDIR/initramfs.testing
-    if ! grep -m 1 -q iscsi-OK $TESTDIR/client.img; then
+    if ! grep -F -m 1 -q iscsi-OK $TESTDIR/client.img; then
 	echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
 	return 1
     fi
@@ -111,6 +111,7 @@ test_setup() {
             [ -f ${_terminfodir}/l/linux ] && break
         done
         dracut_install -o ${_terminfodir}/l/linux
+        inst_simple /etc/os-release
         inst ./client-init.sh /sbin/init
         (cd "$initdir"; mkdir -p dev sys proc etc var/run tmp )
         cp -a /etc/ld.so.conf* $initdir/etc
@@ -152,7 +153,7 @@ test_setup() {
         -kernel "/boot/vmlinuz-$kernel" \
         -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/client.img || return 1
     rm $TESTDIR/client.img
     (
         export initdir=$TESTDIR/overlay
@@ -196,6 +197,7 @@ test_setup() {
         [ -f /etc/netconfig ] && dracut_install /etc/netconfig
         type -P dhcpd >/dev/null && dracut_install dhcpd
         [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
+        inst_simple /etc/os-release
         inst ./server-init.sh /sbin/init
         inst ./hosts /etc/hosts
         inst ./dhcpd.conf /etc/dhcpd.conf

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -64,7 +64,7 @@ client_test() {
         -append "$cmdline $DEBUGFAIL rd.auto rd.info rd.retry=10 ro console=ttyS0,115200n81  selinux=0  " \
         -initrd $TESTDIR/initramfs.testing
 
-    if [[ $? -ne 0 ]] || ! grep -m 1 -q nbd-OK $TESTDIR/flag.img; then
+    if [[ $? -ne 0 ]] || ! grep -F -m 1 -q nbd-OK $TESTDIR/flag.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -205,6 +205,7 @@ make_encrypted_root() {
         done
         dracut_install -o ${_terminfodir}/l/linux
         inst ./client-init.sh /sbin/init
+        inst_simple /etc/os-release
         find_binary plymouth >/dev/null && dracut_install plymouth
         cp -a /etc/ld.so.conf* $initdir/etc
         sudo ldconfig -r "$initdir"
@@ -239,8 +240,8 @@ make_encrypted_root() {
         -kernel "/boot/vmlinuz-$kernel" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
         -initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
-    grep -a -m 1 ID_FS_UUID $TESTDIR/flag.img > $TESTDIR/luks.uuid
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/flag.img || return 1
+    grep -F -a -m 1 ID_FS_UUID $TESTDIR/flag.img > $TESTDIR/luks.uuid
 }
 
 make_client_root() {
@@ -262,6 +263,7 @@ make_client_root() {
         done
         dracut_install -o ${_terminfodir}/l/linux
         inst ./client-init.sh /sbin/init
+        inst_simple /etc/os-release
         inst /etc/nsswitch.conf /etc/nsswitch.conf
         inst /etc/passwd /etc/passwd
         inst /etc/group /etc/group
@@ -303,6 +305,7 @@ make_server_root() {
         type -P dhcpd >/dev/null && dracut_install dhcpd
         [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
         inst ./server-init.sh /sbin/init
+        inst_simple /etc/os-release
         inst ./hosts /etc/hosts
         inst ./dhcpd.conf /etc/dhcpd.conf
         inst /etc/nsswitch.conf /etc/nsswitch.conf

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -61,7 +61,7 @@ client_test() {
         -append "$cmdline $DEBUGFAIL rd.retry=5 rd.info ro console=ttyS0,115200n81 selinux=0 init=/sbin/init" \
         -initrd $TESTDIR/initramfs.testing
 
-    if [[ $? -ne 0 ]] || ! grep -m 1 -q OK $TESTDIR/client.img; then
+    if [[ $? -ne 0 ]] || ! grep -F -m 1 -q OK $TESTDIR/client.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -69,7 +69,7 @@ client_test() {
 
     for i in $check ; do
         echo $i
-        if ! grep -m 1 -q $i $TESTDIR/client.img; then
+        if ! grep -F -m 1 -q $i $TESTDIR/client.img; then
             echo "CLIENT TEST END: $test_name [FAILED - BAD IF]"
             return 1
         fi
@@ -170,6 +170,7 @@ test_setup() {
         type -P dhcpd >/dev/null && dracut_install dhcpd
         [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
         instmods nfsd sunrpc ipv6 lockd af_packet
+        inst_simple /etc/os-release
         inst ./server-init.sh /sbin/init
         inst ./hosts /etc/hosts
         inst ./exports /etc/exports
@@ -208,6 +209,7 @@ test_setup() {
             [ -f ${_terminfodir}/l/linux ] && break
         done
         dracut_install -o ${_terminfodir}/l/linux
+        inst_simple /etc/os-release
         inst ./client-init.sh /sbin/init
         (
             cd "$initdir"

--- a/test/TEST-99-RPM/test.sh
+++ b/test/TEST-99-RPM/test.sh
@@ -53,7 +53,7 @@ find / -xdev -type f -not -path '/var/*' \
   -not -path '/boot/*0-rescue*' \
   -not -path '/dev/null' \
   -exec rpm -qf '{}' ';' | \
-  fgrep 'not owned' &> /test.output
+  grep -F 'not owned' &> /test.output
 exit
 EOF
 

--- a/test/old.TEST-14-IMSM/test.sh
+++ b/test/old.TEST-14-IMSM/test.sh
@@ -17,7 +17,7 @@ client_run() {
 	-net none -kernel /boot/vmlinuz-$KVERSION \
 	-append "$@ root=LABEL=root rw quiet rd.retry=5 rd.debug console=ttyS0,115200n81 selinux=0 rd.info $DEBUGFAIL" \
 	-initrd $TESTDIR/initramfs.testing
-    if ! grep -m 1 -q dracut-root-block-success $TESTDIR/root.ext2; then
+    if ! grep -F -m 1 -q dracut-root-block-success $TESTDIR/root.ext2; then
 	echo "CLIENT TEST END: $@ [FAIL]"
 	return 1;
     fi
@@ -102,7 +102,7 @@ test_setup() {
 	-kernel "/boot/vmlinuz-$kernel" \
 	-append "root=/dev/dracut/root rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
 	-initrd $TESTDIR/initramfs.makeroot  || return 1
-    grep -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
+    grep -F -m 1 -q dracut-root-block-created $TESTDIR/root.ext2 || return 1
     (
 	export initdir=$TESTDIR/overlay
 	. $basedir/dracut-functions.sh


### PR DESCRIPTION
These commits add functions to parse network related variables from Kernel cmdline options (e.g. `var=%{hostname}`) and a bare-bones implementation for hostname, in case the executable is not available.

I will follow this up (once it is accepted) with commits that actually make use of it to allow mounting of NFS paths with variables in them. (My feature/nfsmounts branch.)