### PR TITLE
Make get_ip actually useable.

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -5,6 +5,7 @@ get_ip() {
     ip=$(ip -o -f inet addr show $iface)
     ip=${ip%%/*}
     ip=${ip##* }
+    echo $ip
 }
 
 iface_for_remote_addr() {


### PR DESCRIPTION
Only place currently using it actually expects that behaviour anyways , see modules.d/95nfs/nfs-lib.sh L27
so this would fix a potential bug too.