### PR TITLE
90dm/dm-shutdown.sh: dmsetup remove_all -> dmsetup remove

### DIFF
--- a/modules.d/90dm/dm-shutdown.sh
+++ b/modules.d/90dm/dm-shutdown.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 _do_dm_shutdown() {
-    local ret
+    local ret=0
     local final=$1
     info "Disassembling device-mapper devices"
-    dmsetup -v remove_all
-    ret=$?
+    for dev in `dmsetup info -c --noheadings -o name` ; do
+        dmsetup -v --noudevsync remove $dev || ret=$?
+    done
     if [ "x$final" != "x" ]; then
         info "dmsetup ls --tree"
         dmsetup ls --tree 2>&1 | vinfo

--- a/modules.d/90dm/dm-shutdown.sh
+++ b/modules.d/90dm/dm-shutdown.sh
@@ -5,7 +5,7 @@ _do_dm_shutdown() {
     local final=$1
     info "Disassembling device-mapper devices"
     for dev in `dmsetup info -c --noheadings -o name` ; do
-        dmsetup -v --noudevsync remove $dev || ret=$?
+        dmsetup -v --noudevsync remove "$dev" || ret=$?
     done
     if [ "x$final" != "x" ]; then
         info "dmsetup ls --tree"


### PR DESCRIPTION
The function 99shutdown/shutdown.sh:_check_shutdown() assumes that shutdown scripts report success or failure via their return value. However, "dmsetup remove_all" always reports success, even if some of the device mappings could not be removed.

I submitted a [patch for dmsetup](https://www.redhat.com/archives/lvm-devel/2014-December/msg00001.html) but the lvm2 folks [rejected it](https://www.redhat.com/archives/lvm-devel/2014-December/msg00004.html), asserting that its behaviour is correct, that "remove_all" should only be used by developers and that the proper solution would be to invoke "dmsetup remove" on each device. This does report success or failure via the return value.

Apart from fixing that issue, this commit also adds the dmsetup option "--noudevsync". Without it, dmsetup would hang after removal of a device while trying to communicate with systemd-udevd, which is no longer running at this shutdown stage.