### PR TITLE
Support /usr/lib/kernel/cmdline fallback path for /etc/kernel/cmdline.

### DIFF
--- a/50-dracut.install
+++ b/50-dracut.install
@@ -20,6 +20,8 @@ case "$COMMAND" in
 
         if [[ -f /etc/kernel/cmdline ]]; then
             readarray -t BOOT_OPTIONS < /etc/kernel/cmdline
+        elif [[ -f /usr/lib/kernel/cmdline ]]; then
+            readarray -t BOOT_OPTIONS < /usr/lib/kernel/cmdline
         fi
 
         if ! [[ "${BOOT_OPTIONS[@]}" ]]; then

--- a/51-dracut-rescue.install
+++ b/51-dracut-rescue.install
@@ -41,6 +41,8 @@ fi
 
 if [[ -f /etc/kernel/cmdline ]]; then
     readarray -t BOOT_OPTIONS < /etc/kernel/cmdline
+elif [[ -f /usr/lib/kernel/cmdline ]]; then
+    readarray -t BOOT_OPTIONS < /usr/lib/kernel/cmdline
 fi
 if ! [[ "${BOOT_OPTIONS[@]}" ]]; then
     read -ar BOOT_OPTIONS < /proc/cmdline


### PR DESCRIPTION
This allows distributions to ship the default in /usr/lib, yet continue to allow admins to override it via /etc/kernel/cmdline. This in general follows masking/overlay configuration directories used elsewhere, e.g. in udev, systemd, XDG, etc.