### PR TITLE
crypt-loop: Always include 'loop' kernel module

### DIFF
--- a/modules.d/91crypt-loop/module-setup.sh
+++ b/modules.d/91crypt-loop/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods loop
+    hostonly='' instmods loop
 }
 
 # called by dracut


### PR DESCRIPTION
When the 'loop' kernel module isn't loaded in a running system, it gets
excluded from the hostonly initrd.  Given that the crypt-loop dracut
module has to be included explicitly anyway, it makes sense to always
include the requisite loop kernel module.