### PR TITLE
Fix ask_for_password bug breaking bash without plymouth

### DIFF
--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -42,10 +42,10 @@ ask_for_password() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --cmd) ply_cmd="$2"; tty_cmd="$2" shift;;
+            --cmd) ply_cmd="$2"; tty_cmd="$2"; shift;;
             --ply-cmd) ply_cmd="$2"; shift;;
             --tty-cmd) tty_cmd="$2"; shift;;
-            --prompt) ply_prompt="$2"; tty_prompt="$2" shift;;
+            --prompt) ply_prompt="$2"; tty_prompt="$2"; shift;;
             --ply-prompt) ply_prompt="$2"; shift;;
             --tty-prompt) tty_prompt="$2"; shift;;
             --tries) ply_tries="$2"; tty_tries="$2"; shift;;


### PR DESCRIPTION
If `crypt-lib.sh` is sourced from any `#!/bin/sh` script, a POSIX shell quirk is in effect that causes variable assignments to "special builtins" (such as `shift`) to leak to their context. So the buggy code works even despite the missing semicolons.

But if it is sourced by "bash acting under its own name", i.e. from any `#!/bin/bash` script, the quirk is disabled, `tty_cmd`/`tty_prompt` are undefined, and `ask_for_password` doesn't do anything if plymouth is not present.