### PR TITLE
Respect LVM activationskip

### DIFF
--- a/dracut.cmdline.7.asc
+++ b/dracut.cmdline.7.asc
@@ -838,6 +838,18 @@ can be found.  By default, this is __LiveOS__.
 Copy the complete image to RAM and use this for booting. This is useful
 when the image resides on i.e. a DVD which needs to be ejected later on.
 
+**rd.live.overlay=**_<devspec>_:_(<pathspec>|auto)__
+Allow the usage of a permanent overlay.
+_<devspec>_ specifies the path to a device with a mountable filesystem.
+_<pathspec>_ is the path to a file within that filesystem, which shall be used to
+persist the changes made to the device specified by **root=live:__<url>__** option.
++
+[listing]
+.Example
+--
+rd.live.overlay=/dev/sdb1:persistent-overlay.img
+--
+
 **rd.live.overlay.thin=**1::
 Enables the usage of thin snapshots instead of classic dm snapshots.
 The advantage of thin snapshots is, that they support discards, and will free

--- a/modules.d/90lvm/lvm_scan.sh
+++ b/modules.d/90lvm/lvm_scan.sh
@@ -106,6 +106,10 @@ if [ -n "$LVS" ] ; then
     info "Scanning devices $lvmdevs for LVM logical volumes $LVS"
     lvm lvscan --ignorelockingfailure 2>&1 | vinfo
     for LV in $LVS; do
+        if [ "x$(lvm lvs --noheadings --select "lv_attr =~ k" $LV | wc -l)" = "x0" ]; then
+            info "Skipping activation of '$LV' because activationskip is set."
+            continue
+        fi
         if [ -z "$sysinit" ]; then
             lvm lvchange --yes -ay --ignorelockingfailure $nopoll --ignoremonitoring $LV 2>&1 | vinfo
         else


### PR DESCRIPTION
One of the two patches will skip the activation of LVs which have the activationskip bit set.

https://bugzilla.redhat.com/show_bug.cgi?id=1186854