### PR TITLE
Fix default udev & systemd dir detection, in usr-merge configurations.

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1300,7 +1300,7 @@ done
 [[ -d $udevdir ]] \
     || udevdir="$(pkg-config udev --variable=udevdir 2>/dev/null)"
 if ! [[ -d "$udevdir" ]]; then
-    [[ -d /lib/udev ]] && udevdir=/lib/udev
+    [[ ! -h /lib ]] && [[ -d /lib/udev ]] && udevdir=/lib/udev
     [[ -d /usr/lib/udev ]] && udevdir=/usr/lib/udev
 fi
 
@@ -1308,7 +1308,7 @@ fi
     || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
 
 if ! [[ -d "$systemdutildir" ]]; then
-    [[ -d /lib/systemd ]] && systemdutildir=/lib/systemd
+    [[ ! -h /lib ]] && [[ -d /lib/systemd ]] && systemdutildir=/lib/systemd
     [[ -d /usr/lib/systemd ]] && systemdutildir=/usr/lib/systemd
 fi
 


### PR DESCRIPTION
Test that /lib is not a symlink, before using split-usr paths.