### PR TITLE
dmsquash-live: Add wc

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -22,7 +22,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple umount dmsetup blkid dd losetup grep blockdev find
+    inst_multiple umount dmsetup blkid dd losetup grep blockdev find wc
     inst_multiple -o checkisomd5
     inst_hook cmdline 30 "$moddir/parse-dmsquash-live.sh"
     inst_hook cmdline 31 "$moddir/parse-iso-scan.sh"


### PR DESCRIPTION
Commit cfa365a32d introduced a dependency on wc, but wc was not added.
This patch takes care to install wc.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>