### PR TITLE
skipcpio.c: Linux only accepts 070701 cpio magic, this also fixes a c…

### DIFF
--- a/skipcpio/skipcpio.c
+++ b/skipcpio/skipcpio.c
@@ -59,9 +59,8 @@ int main(int argc, char **argv)
         }
         fseek(f, 0, SEEK_SET);
 
-        /* check, if this is a cpio archive */
-        if ((buf[0] == 0x71 && buf[1] == 0xc7)
-            || (buf[0] == '0' && buf[1] == '7' && buf[2] == '0' && buf[3] == '7' && buf[4] == '0' && buf[5] == '1')) {
+        /* check, if this is a cpio archive, linux only accepts "070701" */
+        if (!memcmp(buf "070701", 6)) {
                 long pos = 0;
 
                 /* Search for CPIO_END */


### PR DESCRIPTION
…omparision of signed char to 0xc7 (type limits)