### PR TITLE
40network/net-lib.sh: get_ip() Add missing echo to output the result

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -5,6 +5,7 @@ get_ip() {
     ip=$(ip -o -f inet addr show $iface)
     ip=${ip%%/*}
     ip=${ip##* }
+    echo $ip
 }
 
 iface_for_remote_addr() {


### PR DESCRIPTION
Only place this function is currently called seems from line 28 in modules.d/95nfs/nfs-lib.sh. Potential bug fix.