### PR TITLE
Honor DRACUT_CPIO_NO_MTIME environment variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1651,6 +1651,9 @@ if [[ $hostonly_cmdline ]] ; then
 fi
 rm -f -- "$outfile"
 dinfo "*** Creating image file '$outfile' ***"
+if [[ -n "${DRACUT_CPIO_NO_MTIME}" ]]; then
+    find "$initdir" -exec touch -h -t 197001010000 {} \;
+fi
 
 if [[ $uefi = yes ]]; then
     uefi_outfile="$outfile"


### PR DESCRIPTION
The OSTree system uses content-addressed storage, and when initramfs
images generated by dracut are in the tree, because the cpio format
contains modification/ctime, it causes a different checksum every time
it's created.

Allow builders to avoid that by using a stable reference time.  This
is not the default, although maybe it should be?

I didn't add a command-line argument because it'd break on older
versions of dracut.