### PR TITLE
dracut-initramfs-restore: make mount error nonfatal

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -14,7 +14,7 @@ SKIP="$dracutbasedir/skipcpio"
 
 [[ -f /etc/machine-id ]] && read MACHINE_ID < /etc/machine-id
 
-mount -o ro /boot &>/dev/null
+mount -o ro /boot &>/dev/null || true
 
 if [[ $MACHINE_ID ]] && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]] ; then
     IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"


### PR DESCRIPTION
Script enables errexit option (set -e). So if /boot is not a mount point
or is already mounted, then script dies after unsuccessful mount
command. Fix this by always returning successful result.