### PR TITLE
The default gateway might need a static route

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -129,6 +129,13 @@ setup_net() {
         fi
     done
 
+    # If a static route was necessary to reach the gateway, the
+    # first gateway setup call will have failed with
+    #     RTNETLINK answers: Network is unreachable
+    # Replace the default route again after static routes to cover
+    # this scenario.
+    [ -e /tmp/net.$netif.gw ]            && . /tmp/net.$netif.gw
+
     # Handle STP Timeout: arping the default gateway.
     # (or the root server, if a) it's local or b) there's no gateway.)
     # Note: This assumes that if no router is present the


### PR DESCRIPTION
Some hosting providers need a static route set in order to be
able to reach the default gateway. Be sure to retry adding
the default gateway after setting the static routes.