### PR TITLE
remove the incomplete .img file

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1651,6 +1651,7 @@ if ! (
             | $compress >> "$outfile"
     ); then
     dfatal "dracut: creation of $outfile failed"
+	rm -f $outfile
     exit 1
 fi
 dinfo "*** Creating initrd image file '$outfile' done ***"


### PR DESCRIPTION
If the directory where the .img file is saved has no enough space, or in
other wrong conditions, dracut will get an incomplete file xxx.img. But
sometimes this .img file will be loaded when rebooting the system. And then
some bugs will happen because this .img file is wrong.

So I think dracut should remove the incomplete file because this .img file
with problems was made by dracut. And then the wrong file will not be loaded
anymore.

Signed-off-by: Chao Fan <cfan@redhat.com>