### PR TITLE
dir-locals: Avoid use of setq which triggers Emacs warning

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,3 @@
-((nil . ((setq sh-basic-offset: 4)
-         (setq indent-tabs-mode nil)
+((nil . ((sh-basic-offset . 4)
+         (indent-tabs-mode . nil)
          )))


### PR DESCRIPTION
Emacs has a whitelist of "safe" variables, using `setq` overrides
that and causes it to warn when opening any file by default.

Dropping the `setq` makes Emacs do the right thing.