### PR TITLE
90qemu: also add ibmvscsi on qemu

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -26,5 +26,5 @@ installkernel() {
         hostonly='' instmods \
             ata_piix ata_generic pata_acpi cdrom sr_mod ahci \
             virtio_blk virtio virtio_ring virtio_pci \
-            virtio_scsi virtio_console spapr-vscsi
+            virtio_scsi virtio_console spapr-vscsi ibmvscsi
 }


### PR DESCRIPTION
Without this module following scenario does not work:
1. Install the guest with virtio-scsi-pci as system disk and no other
data disk.
2. Change the system disk from virtio-scsi to spapr-vscsi.