### PR TITLE
lsinitrd: Suppress "cat: write error: Broken pipe"

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -176,38 +176,35 @@ case $bin in
         ;;
 esac
 
-CAT=$({
-        if [[ $SKIP ]]; then
-            $SKIP "$image"
+if [[ $SKIP ]] ; then
+    bin="$($SKIP "$image" | { read -N 6 bin && echo "$bin" ; })"
+else
+    read -N 6 bin < "$image"
+fi
+case $bin in
+    $'\x1f\x8b'*)
+        CAT="zcat --"
+        ;;
+    BZh*)
+        CAT="bzcat --"
+        ;;
+    $'\x71\xc7'*|070701)
+        CAT="cat --"
+        ;;
+    $'\x02\x21'*)
+        CAT="lz4 -d -c"
+        ;;
+    $'\x89'LZO$'\0'*)
+        CAT="lzop -d -c"
+        ;;
+    *)
+        if echo "test"|xz|xzcat --single-stream >/dev/null 2>&1; then
+            CAT="xzcat --single-stream --"
         else
-            cat "$image"
-        fi } | {
-        read -N 6 bin
-        case $bin in
-            $'\x1f\x8b'*)
-                echo "zcat --"
-                ;;
-            BZh*)
-                echo "bzcat --"
-                ;;
-            $'\x71\xc7'*|070701)
-                echo "cat --"
-                ;;
-            $'\x02\x21'*)
-                echo "lz4 -d -c"
-                ;;
-            $'\x89'LZO$'\0'*)
-                echo "lzop -d -c"
-                ;;
-            *)
-                if echo "test"|xz|xzcat --single-stream >/dev/null 2>&1; then
-                    echo "xzcat --single-stream --"
-                else
-                    echo "xzcat --"
-                fi
-                ;;
-        esac
-    })
+            CAT="xzcat --"
+        fi
+        ;;
+esac
 
 skipcpio()
 {


### PR DESCRIPTION
On systemd, SIGPIPE is ignored by default; see man 5 systemd.exec for
IgnoreSIGPIPE=. As a result, lsinitrd.sh under a systemd service
outputs "cat: write error: Broken pipe" in the processing of
determining a compression format of a given initramfs file using cat
command in the write part of a pipeline processing.

For example, this is a log message of kdump.service in RHEL7.1,

    -- Logs begin at Wed 2015-11-04 09:57:33 JST, end at Wed 2015-11-04 09:58:28 JST. --
    Nov 04 09:57:33 localhost systemd[1]: Stopping Crash recovery kernel arming...
    Nov 04 09:57:33 localhost kdumpctl[22545]: kexec: unloaded kdump kernel
    Nov 04 09:57:33 localhost kdumpctl[22545]: Stopping kdump: [OK]
    Nov 04 09:57:33 localhost systemd[1]: Starting Crash recovery kernel arming...
    Nov 04 09:57:36 localhost kdumpctl[22553]: Detected change(s) in the following file(s):
    Nov 04 09:57:36 localhost kdumpctl[22553]: /etc/kdump.conf
    Nov 04 09:57:36 localhost kdumpctl[22553]: Rebuilding /boot/initramfs-3.10.0-229.el7.x86_64kdump.img
    Nov 04 09:57:40 localhost dracut[24914]: Executing: /usr/sbin/dracut --hostonly --hostonly-cmdline -o "plymouth dash resume" -f /boot/initramfs-3.10.0-229.el7.x86_64kdump.img 3.10.0-229.el7.x86_64
    ...<cut>...
    Nov 04 09:58:12 localhost dracut[24914]: *** Creating image file done ***
    Nov 04 09:58:12 localhost dracut[24914]: Image: /boot/initramfs-3.10.0-229.el7.x86_64kdump.img: 18M
    Nov 04 09:58:12 localhost kdumpctl[22553]: cat: write error: Broken pipe
    Nov 04 09:58:12 localhost dracut[24914]: ========================================================================
    Nov 04 09:58:12 localhost dracut[24914]: Version: dracut-033-240.el7
    Nov 04 09:58:12 localhost dracut[24914]:
    Nov 04 09:58:12 localhost dracut[24914]: Arguments: --hostonly --hostonly-cmdline -o 'plymouth dash resume' -f
    Nov 04 09:58:13 localhost dracut[24914]:
    Nov 04 09:58:13 localhost dracut[24914]: dracut modules:
    Nov 04 09:58:13 localhost dracut[24914]: bash

kdump.service builds and loads an initramfs for kdump kernel using
kdumpctl command which uses dracut command and so lsinitrd command,
too.

Although there's no actual harm except for the error message, there
has been several inquiries from customers about this message so
far. We should suppress this message to reduce needless
communications.

To suppress the message, this commit cleans up the processing of
reading the first 6 bytes of a given initramfs file without cat
command.