### PR TITLE
dmsquash-live-root: Request overflow support for persistent snapshot.

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -171,7 +171,7 @@ do_live_overlay() {
         # Create a snapshot of the base image
         echo 0 $sz thin /dev/mapper/live-overlay-pool 0 $base | dmsetup create live-rw
     else
-        echo 0 $sz snapshot $base $over p 8 | dmsetup create live-rw
+        echo 0 $sz snapshot $base $over PO 8 | dmsetup create live-rw
     fi
 
     # Create a device that always points to a ro base image


### PR DESCRIPTION
With kernel 4.3, we can take advantage of the Persistence with Overflow snapshot store type.
https://git.kernel.org/cgit/linux/kernel/git/device-mapper/linux-dm.git/commit/?h=dm-4.3&id=b0d3cc011e532d8c9db76cf717bcafa53c135595