### PR TITLE
base/dracut-lib.sh:dev_unit_name() guard against $dev beginning with "-"

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -874,7 +874,7 @@ dev_unit_name()
     local dev="$1"
 
     if command -v systemd-escape >/dev/null; then
-        systemd-escape -p  "$dev"
+        systemd-escape -p -- "$dev"
         return
     fi
 


### PR DESCRIPTION
crypt/parse-crypt.sh generate initqueue job which always call
dev_unit_name() with an argument beginning with "-". This results
in the following error:

dracut-initqueue[307]: + systemd-escape -p -cfb4aa43-2f02-4c6b-a313-60ea99288087
dracut-initqueue[307]: systemd-escape: invalid option -- 'c'