### PR TITLE
Netboot: don't let NetworkManager manage bonded boot interfaces

### DIFF
--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -221,6 +221,7 @@ for netup in /tmp/net.*.did-setup ; do
             echo "BONDING_OPTS=\"$bondoptions\""
             echo "NAME=\"$netif\""
             echo "TYPE=Bond"
+            echo "NM_CONTROLLED=no"
         } >> /tmp/ifcfg/ifcfg-$netif
 
         for slave in $bondslaves ; do
@@ -234,6 +235,7 @@ for netup in /tmp/net.*.did-setup ; do
                 echo "SLAVE=yes"
                 echo "MASTER=\"$netif\""
                 echo "UUID=\"$(cat /proc/sys/kernel/random/uuid)\""
+                echo "NM_CONTROLLED=no"
                 unset macaddr
                 [ -e /tmp/net.$slave.override ] && . /tmp/net.$slave.override
                 interface_bind "$slave" "$macaddr"


### PR DESCRIPTION
Boot hangs when NetworkManager takes control of bonded boot interfaces.

Other complex interface configurations could need this too, further check is needed.