### PR TITLE
rootfs-generator: use infinity as default timeout value

### DIFF
--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -9,7 +9,7 @@ generator_wait_for_dev()
 
     _name="$(str_replace "$1" '/' '\x2f')"
     _timeout=$(getarg rd.timeout)
-    _timeout=${_timeout:-0}
+    _timeout=${_timeout:-infinity}
 
     if ! [ -e "$hookdir/initqueue/finished/devexists-${_name}.sh" ]; then
 


### PR DESCRIPTION
systemd recently changed the meaning of 0 for timeouts (not in a release yet)
which makes it impossible to boot with dracut as the device timeouts immediately.

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>