### PR TITLE
dracut-systemd/dracut-cmdline-ask: fix dracut --kernel-cmdline=rd.cmdline=ask

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.service
@@ -14,7 +14,8 @@ Before=dracut-cmdline.service
 After=systemd-journald.socket
 Wants=systemd-journald.socket
 ConditionPathExists=/usr/lib/initrd-release
-ConditionKernelCommandLine=rd.cmdline=ask
+ConditionKernelCommandLine=|rd.cmdline=ask
+ConditionPathExistsGlob=|/etc/cmdline.d/*.conf
 
 [Service]
 Environment=DRACUT_SYSTEMD=1

--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+getarg "rd.cmdline=ask" || exit 0
+
 sleep 0.5
 echo
 sleep 0.5


### PR DESCRIPTION
How to reproduce:
```
host# dracut --kernel-cmdline='rd.cmdline=ask' initramfs.img
host# qemu-system-x86_64 -initrd initramfs.img ... -append root=/dev/sda1 ...
...

qemu-host# journalctl -b | grep dracut-cmdline-ask
...
Feb 15 08:45:36 localhost systemd[1]: dracut-cmdline-ask.service: Installed new job dracut-cmdline-ask.service/start as 42
Feb 15 08:45:36 localhost systemd[1]: dracut-cmdline-ask.service: ConditionKernelCommandLine=rd.cmdline=ask failed.
Feb 15 08:45:36 localhost systemd[1]: dracut-cmdline-ask.service: Starting requested but condition failed. Not starting unit.
Feb 15 08:45:36 localhost systemd[1]: dracut-cmdline-ask.service: Job dracut-cmdline-ask.service/start finished, result=done
...
```