### PR TITLE
base/init.sh: don't remove 99-cmdline-ask on 'hostonly' cleanup

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -120,7 +120,9 @@ if getarg "rd.cmdline=ask"; then
 fi
 
 if ! getargbool 1 'rd.hostonly'; then
+    [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
+    [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf
 fi
 
 # run scriptlets to parse the command line


### PR DESCRIPTION
How to reproduce:
```
host# ./dracut.sh -o 'dracut-systemd systemd systemd-initrd' --local -f ./initramfs.img

host# qemu-system-x86_64 -initrd ./initramfs.img \
    -append 'root=/dev/sda1 rd.cmdline=ask rd.hostonly=0' \
    ...

Enter additional kernel command line parameter (end with ctrl-d or .)
> rd.break
> .
...
There is no "Break before switch_root"
...
```