### PR TITLE
dracut-functions.sh:get_persistent_dev() fix persistent policy

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -223,13 +223,18 @@ get_devpath_block() {
 
 # get a persistent path from a device
 get_persistent_dev() {
-    local i j _tmp _dev _pol
+    local i j _dir _tmp _dev _pol
 
     _dev=$(get_maj_min "$1")
     [ -z "$_dev" ] && return
 
-    for j in ${persistent_policy[@]}; do
-	for i in /dev/disk/${i}/*; do
+    for j in $persistent_policy; do
+	case $j in
+	    mapper) _dir=/dev/mapper;;
+	    *) _dir=/dev/disk/${j};;
+	esac
+	[[ -d "$_dir" ]] || continue
+	for i in ${_dir}/*; do
             [[ -e "$i" ]] || continue
             [[ $i == /dev/mapper/control ]] && continue
             [[ $i == /dev/mapper/mpath* ]] && continue

--- a/dracut.8.asc
+++ b/dracut.8.asc
@@ -332,9 +332,13 @@ provide a valid _/etc/fstab_.
 **--persistent-policy** _<policy>_::
     Use _<policy>_ to address disks and partitions.
     _<policy>_ can be any directory name found in /dev/disk.
-    E.g. "by-uuid", "by-label"
+    E.g. "by-uuid", "by-label".
+    As an exception, if _<policy>_ is "mapper", it refers to /dev/mapper
+    rather than /dev/disk/mapper.
     _<policy>_ can also be a list of directories.
-    E.g. the default is "mapper by-uuid by-label by-partuuid by-partlabel by-id by-path"
+    E.g. the default is "mapper by-uuid by-label by-partuuid by-partlabel by-id by-path".
+    This causes dracut generate device IDs from /dev/mapper first, and if this
+    fails, from /dev/disk/by-uuid, /dev/disk/by-label, etc.
 
 **--fstab**::
     Use _/etc/fstab_ instead of _/proc/self/mountinfo_.

--- a/dracut.conf.5.asc
+++ b/dracut.conf.5.asc
@@ -103,6 +103,8 @@ Configuration files must have the extension .conf; other extensions are ignored.
     Use _<policy>_ to address disks and partitions.
     _<policy>_ can be any directory name found in /dev/disk. +
     E.g. "by-uuid", "by-label" +
+    As an exception, if _<policy>_ is "mapper", it refers to /dev/mapper
+    rather than /dev/disk/mapper. +
     _<policy>_ can also be a list of directories. +
     E.g. the default is ( mapper by-uuid by-label by-partuuid by-partlabel by-id by-path )
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -157,6 +157,7 @@ Creates initial ramdisk images for preloading modules
   --persistent-policy [POLICY]
                         Use [POLICY] to address disks and partitions.
                         POLICY can be any directory name found in /dev/disk.
+                        As an exception, if POLICY is "mapper", it refers to /dev/mapper.
                         E.g. "by-uuid", "by-label"
   --fstab               Use /etc/fstab to determine the root device.
   --add-fstab [FILE]    Add file to the initramfs fstab
@@ -733,7 +734,7 @@ stdloglvl=$((stdloglvl + verbosity_mod_l))
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 [[ $persistent_policy_l ]] && persistent_policy=$persistent_policy_l
 # add the default fallback
-persistent_policy+=( mapper by-uuid by-label by-partuuid by-partlabel by-id by-path )
+persistent_policy+=" mapper by-uuid by-label by-partuuid by-partlabel by-id by-path "
 [[ $use_fstab_l ]] && use_fstab=$use_fstab_l
 [[ $mdadmconf_l ]] && mdadmconf=$mdadmconf_l
 [[ $lvmconf_l ]] && lvmconf=$lvmconf_l


### PR DESCRIPTION
"mapper" needs to get special treatment for persistent policy,
and that needs to be explained in the man page.
Also, persistent_policy is not declared as an array at the moment.

I tested this, AFAICT it works as it should.
I said it before: I think in the long run the default should not be "mapper" but "by-id" or "by-uuid".